### PR TITLE
API-Level Metrics Middleware

### DIFF
--- a/api-gateway/internal/middleware/metrics.go
+++ b/api-gateway/internal/middleware/metrics.go
@@ -10,13 +10,14 @@ import (
 	"time"
 )
 
-var latencyBuckets = []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5}
+var latencyBuckets = []float64{0.1, 0.3, 0.5, 1, 2, 5}
 
 type metricKey struct {
-	Service string
-	Method  string
-	Route   string
-	Status  string
+	Service     string
+	Method      string
+	Route       string
+	Status      string
+	StatusGroup string
 }
 
 type metricSnapshot struct {
@@ -92,8 +93,27 @@ func (s *metricsStore) decActive() {
 	s.mu.Unlock()
 }
 
+func statusGroup(code int) string {
+	switch {
+	case code >= 200 && code < 300:
+		return "2xx"
+	case code >= 400 && code < 500:
+		return "4xx"
+	case code >= 500:
+		return "5xx"
+	default:
+		return "other"
+	}
+}
+
 func (s *metricsStore) observe(serviceName string, method string, route string, status int, seconds float64) {
-	key := metricKey{Service: serviceName, Method: method, Route: route, Status: strconv.Itoa(status)}
+	key := metricKey{
+		Service:     serviceName,
+		Method:      method,
+		Route:       route,
+		Status:      strconv.Itoa(status),
+		StatusGroup: statusGroup(status),
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -185,7 +205,10 @@ func sortedMetricKeys(values map[metricKey]uint64) []metricKey {
 }
 
 func (k metricKey) labels() string {
-	return fmt.Sprintf("service=%q,method=%q,route=%q,status=%q", k.Service, k.Method, k.Route, k.Status)
+	return fmt.Sprintf(
+		"service=%q,method=%q,route=%q,status=%q,status_group=%q",
+		k.Service, k.Method, k.Route, k.Status, k.StatusGroup,
+	)
 }
 
 func formatFloat(v float64) string {

--- a/api-gateway/internal/middleware/metrics_test.go
+++ b/api-gateway/internal/middleware/metrics_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -21,7 +22,8 @@ func TestMetricsRecordsLowCardinalityHTTPMetrics(t *testing.T) {
 	MetricsHandler("test-service").ServeHTTP(metricsRec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
 	body := metricsRec.Body.String()
 
-	if !strings.Contains(body, `http_requests_total{service="test-service",method="POST",route="posts",status="201"} 1`) {
+	// Check counter with status_group
+	if !strings.Contains(body, `http_requests_total{service="test-service",method="POST",route="posts",status="201",status_group="2xx"} 1`) {
 		t.Fatalf("missing request counter in metrics body:\n%s", body)
 	}
 	if strings.Contains(body, "post-123") {
@@ -32,5 +34,40 @@ func TestMetricsRecordsLowCardinalityHTTPMetrics(t *testing.T) {
 	}
 	if !strings.Contains(body, "service_operations_total") {
 		t.Fatalf("missing service operation counter:\n%s", body)
+	}
+
+	// Verify histogram buckets
+	requiredBuckets := []string{"0.1", "0.3", "0.5", "1", "2", "5"}
+	for _, le := range requiredBuckets {
+		if !strings.Contains(body, fmt.Sprintf(`le="%s"`, le)) {
+			t.Errorf("missing histogram bucket le=%s in metrics body:\n%s", le, body)
+		}
+	}
+
+	// Verify status_group
+	if !strings.Contains(body, `status_group="2xx"`) {
+		t.Errorf("missing status_group=\"2xx\" label in metrics body:\n%s", body)
+	}
+}
+
+func TestMetricsErrorGrouping(t *testing.T) {
+	defaultMetrics = newMetricsStore()
+	handler := Metrics("test-service")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/posts/123", nil)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	metricsRec := httptest.NewRecorder()
+	MetricsHandler("test-service").ServeHTTP(metricsRec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body := metricsRec.Body.String()
+
+	if !strings.Contains(body, `status_group="5xx"`) {
+		t.Errorf("expected status_group=\"5xx\" for 500 response, got:\n%s", body)
+	}
+
+	if !strings.Contains(body, `status="500"`) {
+		t.Errorf("expected status=\"500\" in metrics body:\n%s", body)
 	}
 }

--- a/auth-service/internal/middleware/metrics.go
+++ b/auth-service/internal/middleware/metrics.go
@@ -10,13 +10,14 @@ import (
 	"time"
 )
 
-var latencyBuckets = []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5}
+var latencyBuckets = []float64{0.1, 0.3, 0.5, 1, 2, 5}
 
 type metricKey struct {
-	Service string
-	Method  string
-	Route   string
-	Status  string
+	Service     string
+	Method      string
+	Route       string
+	Status      string
+	StatusGroup string
 }
 
 type metricSnapshot struct {
@@ -92,8 +93,27 @@ func (s *metricsStore) decActive() {
 	s.mu.Unlock()
 }
 
+func statusGroup(code int) string {
+	switch {
+	case code >= 200 && code < 300:
+		return "2xx"
+	case code >= 400 && code < 500:
+		return "4xx"
+	case code >= 500:
+		return "5xx"
+	default:
+		return "other"
+	}
+}
+
 func (s *metricsStore) observe(serviceName string, method string, route string, status int, seconds float64) {
-	key := metricKey{Service: serviceName, Method: method, Route: route, Status: strconv.Itoa(status)}
+	key := metricKey{
+		Service:     serviceName,
+		Method:      method,
+		Route:       route,
+		Status:      strconv.Itoa(status),
+		StatusGroup: statusGroup(status),
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -185,7 +205,10 @@ func sortedMetricKeys(values map[metricKey]uint64) []metricKey {
 }
 
 func (k metricKey) labels() string {
-	return fmt.Sprintf("service=%q,method=%q,route=%q,status=%q", k.Service, k.Method, k.Route, k.Status)
+	return fmt.Sprintf(
+		"service=%q,method=%q,route=%q,status=%q,status_group=%q",
+		k.Service, k.Method, k.Route, k.Status, k.StatusGroup,
+	)
 }
 
 func formatFloat(v float64) string {

--- a/auth-service/internal/middleware/metrics_test.go
+++ b/auth-service/internal/middleware/metrics_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -21,7 +22,8 @@ func TestMetricsRecordsLowCardinalityHTTPMetrics(t *testing.T) {
 	MetricsHandler("test-service").ServeHTTP(metricsRec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
 	body := metricsRec.Body.String()
 
-	if !strings.Contains(body, `http_requests_total{service="test-service",method="POST",route="posts",status="201"} 1`) {
+	// Check counter with status_group
+	if !strings.Contains(body, `http_requests_total{service="test-service",method="POST",route="posts",status="201",status_group="2xx"} 1`) {
 		t.Fatalf("missing request counter in metrics body:\n%s", body)
 	}
 	if strings.Contains(body, "post-123") {
@@ -32,5 +34,40 @@ func TestMetricsRecordsLowCardinalityHTTPMetrics(t *testing.T) {
 	}
 	if !strings.Contains(body, "service_operations_total") {
 		t.Fatalf("missing service operation counter:\n%s", body)
+	}
+
+	// Verify histogram buckets
+	requiredBuckets := []string{"0.1", "0.3", "0.5", "1", "2", "5"}
+	for _, le := range requiredBuckets {
+		if !strings.Contains(body, fmt.Sprintf(`le="%s"`, le)) {
+			t.Errorf("missing histogram bucket le=%s in metrics body:\n%s", le, body)
+		}
+	}
+
+	// Verify status_group
+	if !strings.Contains(body, `status_group="2xx"`) {
+		t.Errorf("missing status_group=\"2xx\" label in metrics body:\n%s", body)
+	}
+}
+
+func TestMetricsErrorGrouping(t *testing.T) {
+	defaultMetrics = newMetricsStore()
+	handler := Metrics("test-service")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/posts/123", nil)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	metricsRec := httptest.NewRecorder()
+	MetricsHandler("test-service").ServeHTTP(metricsRec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body := metricsRec.Body.String()
+
+	if !strings.Contains(body, `status_group="5xx"`) {
+		t.Errorf("expected status_group=\"5xx\" for 500 response, got:\n%s", body)
+	}
+
+	if !strings.Contains(body, `status="500"`) {
+		t.Errorf("expected status=\"500\" in metrics body:\n%s", body)
 	}
 }

--- a/feed-service/internal/middleware/metrics.go
+++ b/feed-service/internal/middleware/metrics.go
@@ -10,13 +10,14 @@ import (
 	"time"
 )
 
-var latencyBuckets = []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5}
+var latencyBuckets = []float64{0.1, 0.3, 0.5, 1, 2, 5}
 
 type metricKey struct {
-	Service string
-	Method  string
-	Route   string
-	Status  string
+	Service     string
+	Method      string
+	Route       string
+	Status      string
+	StatusGroup string
 }
 
 type metricSnapshot struct {
@@ -92,8 +93,27 @@ func (s *metricsStore) decActive() {
 	s.mu.Unlock()
 }
 
+func statusGroup(code int) string {
+	switch {
+	case code >= 200 && code < 300:
+		return "2xx"
+	case code >= 400 && code < 500:
+		return "4xx"
+	case code >= 500:
+		return "5xx"
+	default:
+		return "other"
+	}
+}
+
 func (s *metricsStore) observe(serviceName string, method string, route string, status int, seconds float64) {
-	key := metricKey{Service: serviceName, Method: method, Route: route, Status: strconv.Itoa(status)}
+	key := metricKey{
+		Service:     serviceName,
+		Method:      method,
+		Route:       route,
+		Status:      strconv.Itoa(status),
+		StatusGroup: statusGroup(status),
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -185,7 +205,10 @@ func sortedMetricKeys(values map[metricKey]uint64) []metricKey {
 }
 
 func (k metricKey) labels() string {
-	return fmt.Sprintf("service=%q,method=%q,route=%q,status=%q", k.Service, k.Method, k.Route, k.Status)
+	return fmt.Sprintf(
+		"service=%q,method=%q,route=%q,status=%q,status_group=%q",
+		k.Service, k.Method, k.Route, k.Status, k.StatusGroup,
+	)
 }
 
 func formatFloat(v float64) string {

--- a/feed-service/internal/middleware/metrics_test.go
+++ b/feed-service/internal/middleware/metrics_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -21,7 +22,8 @@ func TestMetricsRecordsLowCardinalityHTTPMetrics(t *testing.T) {
 	MetricsHandler("test-service").ServeHTTP(metricsRec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
 	body := metricsRec.Body.String()
 
-	if !strings.Contains(body, `http_requests_total{service="test-service",method="POST",route="posts",status="201"} 1`) {
+	// Check counter with status_group
+	if !strings.Contains(body, `http_requests_total{service="test-service",method="POST",route="posts",status="201",status_group="2xx"} 1`) {
 		t.Fatalf("missing request counter in metrics body:\n%s", body)
 	}
 	if strings.Contains(body, "post-123") {
@@ -32,5 +34,40 @@ func TestMetricsRecordsLowCardinalityHTTPMetrics(t *testing.T) {
 	}
 	if !strings.Contains(body, "service_operations_total") {
 		t.Fatalf("missing service operation counter:\n%s", body)
+	}
+
+	// Verify histogram buckets
+	requiredBuckets := []string{"0.1", "0.3", "0.5", "1", "2", "5"}
+	for _, le := range requiredBuckets {
+		if !strings.Contains(body, fmt.Sprintf(`le="%s"`, le)) {
+			t.Errorf("missing histogram bucket le=%s in metrics body:\n%s", le, body)
+		}
+	}
+
+	// Verify status_group
+	if !strings.Contains(body, `status_group="2xx"`) {
+		t.Errorf("missing status_group=\"2xx\" label in metrics body:\n%s", body)
+	}
+}
+
+func TestMetricsErrorGrouping(t *testing.T) {
+	defaultMetrics = newMetricsStore()
+	handler := Metrics("test-service")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/posts/123", nil)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	metricsRec := httptest.NewRecorder()
+	MetricsHandler("test-service").ServeHTTP(metricsRec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body := metricsRec.Body.String()
+
+	if !strings.Contains(body, `status_group="5xx"`) {
+		t.Errorf("expected status_group=\"5xx\" for 500 response, got:\n%s", body)
+	}
+
+	if !strings.Contains(body, `status="500"`) {
+		t.Errorf("expected status=\"500\" in metrics body:\n%s", body)
 	}
 }

--- a/notification-service/internal/middleware/metrics.go
+++ b/notification-service/internal/middleware/metrics.go
@@ -10,13 +10,14 @@ import (
 	"time"
 )
 
-var latencyBuckets = []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5}
+var latencyBuckets = []float64{0.1, 0.3, 0.5, 1, 2, 5}
 
 type metricKey struct {
-	Service string
-	Method  string
-	Route   string
-	Status  string
+	Service     string
+	Method      string
+	Route       string
+	Status      string
+	StatusGroup string
 }
 
 type metricSnapshot struct {
@@ -92,8 +93,27 @@ func (s *metricsStore) decActive() {
 	s.mu.Unlock()
 }
 
+func statusGroup(code int) string {
+	switch {
+	case code >= 200 && code < 300:
+		return "2xx"
+	case code >= 400 && code < 500:
+		return "4xx"
+	case code >= 500:
+		return "5xx"
+	default:
+		return "other"
+	}
+}
+
 func (s *metricsStore) observe(serviceName string, method string, route string, status int, seconds float64) {
-	key := metricKey{Service: serviceName, Method: method, Route: route, Status: strconv.Itoa(status)}
+	key := metricKey{
+		Service:     serviceName,
+		Method:      method,
+		Route:       route,
+		Status:      strconv.Itoa(status),
+		StatusGroup: statusGroup(status),
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -185,7 +205,10 @@ func sortedMetricKeys(values map[metricKey]uint64) []metricKey {
 }
 
 func (k metricKey) labels() string {
-	return fmt.Sprintf("service=%q,method=%q,route=%q,status=%q", k.Service, k.Method, k.Route, k.Status)
+	return fmt.Sprintf(
+		"service=%q,method=%q,route=%q,status=%q,status_group=%q",
+		k.Service, k.Method, k.Route, k.Status, k.StatusGroup,
+	)
 }
 
 func formatFloat(v float64) string {

--- a/notification-service/internal/middleware/metrics_test.go
+++ b/notification-service/internal/middleware/metrics_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -21,7 +22,8 @@ func TestMetricsRecordsLowCardinalityHTTPMetrics(t *testing.T) {
 	MetricsHandler("test-service").ServeHTTP(metricsRec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
 	body := metricsRec.Body.String()
 
-	if !strings.Contains(body, `http_requests_total{service="test-service",method="POST",route="posts",status="201"} 1`) {
+	// Check counter with status_group
+	if !strings.Contains(body, `http_requests_total{service="test-service",method="POST",route="posts",status="201",status_group="2xx"} 1`) {
 		t.Fatalf("missing request counter in metrics body:\n%s", body)
 	}
 	if strings.Contains(body, "post-123") {
@@ -32,5 +34,40 @@ func TestMetricsRecordsLowCardinalityHTTPMetrics(t *testing.T) {
 	}
 	if !strings.Contains(body, "service_operations_total") {
 		t.Fatalf("missing service operation counter:\n%s", body)
+	}
+
+	// Verify histogram buckets
+	requiredBuckets := []string{"0.1", "0.3", "0.5", "1", "2", "5"}
+	for _, le := range requiredBuckets {
+		if !strings.Contains(body, fmt.Sprintf(`le="%s"`, le)) {
+			t.Errorf("missing histogram bucket le=%s in metrics body:\n%s", le, body)
+		}
+	}
+
+	// Verify status_group
+	if !strings.Contains(body, `status_group="2xx"`) {
+		t.Errorf("missing status_group=\"2xx\" label in metrics body:\n%s", body)
+	}
+}
+
+func TestMetricsErrorGrouping(t *testing.T) {
+	defaultMetrics = newMetricsStore()
+	handler := Metrics("test-service")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/posts/123", nil)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	metricsRec := httptest.NewRecorder()
+	MetricsHandler("test-service").ServeHTTP(metricsRec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body := metricsRec.Body.String()
+
+	if !strings.Contains(body, `status_group="5xx"`) {
+		t.Errorf("expected status_group=\"5xx\" for 500 response, got:\n%s", body)
+	}
+
+	if !strings.Contains(body, `status="500"`) {
+		t.Errorf("expected status=\"500\" in metrics body:\n%s", body)
 	}
 }

--- a/posts-service/internal/middleware/metrics.go
+++ b/posts-service/internal/middleware/metrics.go
@@ -10,13 +10,14 @@ import (
 	"time"
 )
 
-var latencyBuckets = []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5}
+var latencyBuckets = []float64{0.1, 0.3, 0.5, 1, 2, 5}
 
 type metricKey struct {
-	Service string
-	Method  string
-	Route   string
-	Status  string
+	Service     string
+	Method      string
+	Route       string
+	Status      string
+	StatusGroup string
 }
 
 type metricSnapshot struct {
@@ -92,8 +93,27 @@ func (s *metricsStore) decActive() {
 	s.mu.Unlock()
 }
 
+func statusGroup(code int) string {
+	switch {
+	case code >= 200 && code < 300:
+		return "2xx"
+	case code >= 400 && code < 500:
+		return "4xx"
+	case code >= 500:
+		return "5xx"
+	default:
+		return "other"
+	}
+}
+
 func (s *metricsStore) observe(serviceName string, method string, route string, status int, seconds float64) {
-	key := metricKey{Service: serviceName, Method: method, Route: route, Status: strconv.Itoa(status)}
+	key := metricKey{
+		Service:     serviceName,
+		Method:      method,
+		Route:       route,
+		Status:      strconv.Itoa(status),
+		StatusGroup: statusGroup(status),
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -185,7 +205,10 @@ func sortedMetricKeys(values map[metricKey]uint64) []metricKey {
 }
 
 func (k metricKey) labels() string {
-	return fmt.Sprintf("service=%q,method=%q,route=%q,status=%q", k.Service, k.Method, k.Route, k.Status)
+	return fmt.Sprintf(
+		"service=%q,method=%q,route=%q,status=%q,status_group=%q",
+		k.Service, k.Method, k.Route, k.Status, k.StatusGroup,
+	)
 }
 
 func formatFloat(v float64) string {

--- a/posts-service/internal/middleware/metrics_test.go
+++ b/posts-service/internal/middleware/metrics_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -21,7 +22,8 @@ func TestMetricsRecordsLowCardinalityHTTPMetrics(t *testing.T) {
 	MetricsHandler("test-service").ServeHTTP(metricsRec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
 	body := metricsRec.Body.String()
 
-	if !strings.Contains(body, `http_requests_total{service="test-service",method="POST",route="posts",status="201"} 1`) {
+	// Check counter with status_group
+	if !strings.Contains(body, `http_requests_total{service="test-service",method="POST",route="posts",status="201",status_group="2xx"} 1`) {
 		t.Fatalf("missing request counter in metrics body:\n%s", body)
 	}
 	if strings.Contains(body, "post-123") {
@@ -32,5 +34,40 @@ func TestMetricsRecordsLowCardinalityHTTPMetrics(t *testing.T) {
 	}
 	if !strings.Contains(body, "service_operations_total") {
 		t.Fatalf("missing service operation counter:\n%s", body)
+	}
+
+	// Verify histogram buckets
+	requiredBuckets := []string{"0.1", "0.3", "0.5", "1", "2", "5"}
+	for _, le := range requiredBuckets {
+		if !strings.Contains(body, fmt.Sprintf(`le="%s"`, le)) {
+			t.Errorf("missing histogram bucket le=%s in metrics body:\n%s", le, body)
+		}
+	}
+
+	// Verify status_group
+	if !strings.Contains(body, `status_group="2xx"`) {
+		t.Errorf("missing status_group=\"2xx\" label in metrics body:\n%s", body)
+	}
+}
+
+func TestMetricsErrorGrouping(t *testing.T) {
+	defaultMetrics = newMetricsStore()
+	handler := Metrics("test-service")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/posts/123", nil)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	metricsRec := httptest.NewRecorder()
+	MetricsHandler("test-service").ServeHTTP(metricsRec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body := metricsRec.Body.String()
+
+	if !strings.Contains(body, `status_group="5xx"`) {
+		t.Errorf("expected status_group=\"5xx\" for 500 response, got:\n%s", body)
+	}
+
+	if !strings.Contains(body, `status="500"`) {
+		t.Errorf("expected status=\"500\" in metrics body:\n%s", body)
 	}
 }

--- a/users-service/internal/middleware/metrics.go
+++ b/users-service/internal/middleware/metrics.go
@@ -10,13 +10,14 @@ import (
 	"time"
 )
 
-var latencyBuckets = []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5}
+var latencyBuckets = []float64{0.1, 0.3, 0.5, 1, 2, 5}
 
 type metricKey struct {
-	Service string
-	Method  string
-	Route   string
-	Status  string
+	Service     string
+	Method      string
+	Route       string
+	Status      string
+	StatusGroup string
 }
 
 type metricSnapshot struct {
@@ -92,8 +93,27 @@ func (s *metricsStore) decActive() {
 	s.mu.Unlock()
 }
 
+func statusGroup(code int) string {
+	switch {
+	case code >= 200 && code < 300:
+		return "2xx"
+	case code >= 400 && code < 500:
+		return "4xx"
+	case code >= 500:
+		return "5xx"
+	default:
+		return "other"
+	}
+}
+
 func (s *metricsStore) observe(serviceName string, method string, route string, status int, seconds float64) {
-	key := metricKey{Service: serviceName, Method: method, Route: route, Status: strconv.Itoa(status)}
+	key := metricKey{
+		Service:     serviceName,
+		Method:      method,
+		Route:       route,
+		Status:      strconv.Itoa(status),
+		StatusGroup: statusGroup(status),
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -185,7 +205,10 @@ func sortedMetricKeys(values map[metricKey]uint64) []metricKey {
 }
 
 func (k metricKey) labels() string {
-	return fmt.Sprintf("service=%q,method=%q,route=%q,status=%q", k.Service, k.Method, k.Route, k.Status)
+	return fmt.Sprintf(
+		"service=%q,method=%q,route=%q,status=%q,status_group=%q",
+		k.Service, k.Method, k.Route, k.Status, k.StatusGroup,
+	)
 }
 
 func formatFloat(v float64) string {

--- a/users-service/internal/middleware/metrics_test.go
+++ b/users-service/internal/middleware/metrics_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -21,7 +22,8 @@ func TestMetricsRecordsLowCardinalityHTTPMetrics(t *testing.T) {
 	MetricsHandler("test-service").ServeHTTP(metricsRec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
 	body := metricsRec.Body.String()
 
-	if !strings.Contains(body, `http_requests_total{service="test-service",method="POST",route="posts",status="201"} 1`) {
+	// Check counter with status_group
+	if !strings.Contains(body, `http_requests_total{service="test-service",method="POST",route="posts",status="201",status_group="2xx"} 1`) {
 		t.Fatalf("missing request counter in metrics body:\n%s", body)
 	}
 	if strings.Contains(body, "post-123") {
@@ -32,5 +34,40 @@ func TestMetricsRecordsLowCardinalityHTTPMetrics(t *testing.T) {
 	}
 	if !strings.Contains(body, "service_operations_total") {
 		t.Fatalf("missing service operation counter:\n%s", body)
+	}
+
+	// Verify histogram buckets
+	requiredBuckets := []string{"0.1", "0.3", "0.5", "1", "2", "5"}
+	for _, le := range requiredBuckets {
+		if !strings.Contains(body, fmt.Sprintf(`le="%s"`, le)) {
+			t.Errorf("missing histogram bucket le=%s in metrics body:\n%s", le, body)
+		}
+	}
+
+	// Verify status_group
+	if !strings.Contains(body, `status_group="2xx"`) {
+		t.Errorf("missing status_group=\"2xx\" label in metrics body:\n%s", body)
+	}
+}
+
+func TestMetricsErrorGrouping(t *testing.T) {
+	defaultMetrics = newMetricsStore()
+	handler := Metrics("test-service")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/posts/123", nil)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	metricsRec := httptest.NewRecorder()
+	MetricsHandler("test-service").ServeHTTP(metricsRec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body := metricsRec.Body.String()
+
+	if !strings.Contains(body, `status_group="5xx"`) {
+		t.Errorf("expected status_group=\"5xx\" for 500 response, got:\n%s", body)
+	}
+
+	if !strings.Contains(body, `status="500"`) {
+		t.Errorf("expected status=\"500\" in metrics body:\n%s", body)
 	}
 }


### PR DESCRIPTION
Implements #77 
  - #78 
  - #79 
  - #80 
  - #81 

- Add status_group label (2xx/4xx/5xx) for error tracking
- Update histogram buckets to spec [0.1,0.3,0.5,1,2,5] seconds
- Add TestMetricsErrorGrouping for 5xx error verification
- Add bucket boundary verification in tests

All 6 services passing.